### PR TITLE
使用 JS “自带的函数”进行 utf8 的编解码以及修改部分代码结构

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+npm-debug.log

--- a/package.json
+++ b/package.json
@@ -20,5 +20,8 @@
   "bugs": {
     "url": "https://github.com/jrainlau/sphinx/issues"
   },
-  "homepage": "https://github.com/jrainlau/sphinx#readme"
+  "homepage": "https://github.com/jrainlau/sphinx#readme",
+  "devDependencies": {
+    "qunitjs": "^2.1.1"
+  }
 }

--- a/src/sphinx.js
+++ b/src/sphinx.js
@@ -4,93 +4,173 @@
  * Version: 0.0.4
  */
 ;(() => {
-	
-const encodeUTF8 = Symbol('encodeUTF8')
-/**
- * Construct a new Sphinx instance by passing the configuration object
- *
- * @param {Object}	config    define the type of the image
- */
-class Sphinx {
-	constructor (config = {img: 'png'}) {
-		this.config = config
+
+  const encodeUTF8 = Symbol('encodeUTF8')
+  /**
+   * Construct a new Sphinx instance by passing the configuration object
+   *
+   * @param {Object}	config    define the type of the image
+   */
+  class Sphinx {
+    constructor (config = {img: 'png'}) {
+      this.config = config
+      this.canvas = document.createElement('canvas')
+    }
+
+    [encodeUTF8] (str) {
+      return str
+	.replace(/[\u0080-\u07ff]/g, (s) => {
+	  let _s = s.charCodeAt(0)
+	  return String.fromCharCode(0xc0 | _s >> 6, 0x80 | _s & 0x3f)
+	})
+	.replace(/[\u0800-\uffff]/g, (s) => {
+	  let _s = s.charCodeAt(0)
+	  return String.fromCharCode(0xe0 | _s >> 12, 0x80 | _s >> 6 & 0x3f, 0x80 | _s & 0x3f)
+	})
+    }
+
+    decodeUTF8 (code) {
+      // http://creamidea.github.io/static/html/articles/Unicode-And-UTF8.html#org5ae6e83
+      let container = [], // 存储 unicode 的容器
+          c, // 当前字节
+          next, // 下一个字节
+          i = -1 // 循环指示器
+
+      while((c = code.charCodeAt(++i))) {
+        // c = 255 时，不会进入这里
+        // 所以也就不需要比较 i % 4 === 0
+        if ( c < 128) {
+          // 0XXXX XXXX
+          c = 0x7f & c
+        } else if (c < 224) {
+          // 110X XXXX
+          c = ((0x1f & c) << 6)
+          // TODO: 这里也许有爆栈的可能
+          while (isNaN(next = code.charCodeAt(++i))) continue
+          c = c | (0x3f & next)
+        } else if (c < 240) {
+          // 1110 XXXX
+          c = ((0x0f & c) << 12)
+          while (isNaN(next = code.charCodeAt(++i))) continue
+          c = c | ((0x3f & next) << 6)
+          while (isNaN(next = code.charCodeAt(++i))) continue
+          c = c | (0x3f & next)
+        }
+        container.push(c)
+      }
+
+      return String.fromCharCode.apply(null, container)
+    }
+
+    /**
+     * @param {array} buffer
+     * @return {CanvasRenderingContext2D} ctx
+     */
+    createContainer(buffer) {
+      let pixelNum,
+          canvas = this.canvas,
+          ctx
+
+      // buffer.length = 4 * width * height
+      pixelNum = buffer.length / 4 // One pixel could store 4 bytes by its RGB+Alpha
+      canvas.height = 1
+      canvas.width = pixelNum
+      ctx = canvas.getContext('2d')
+      return ctx
+    }
+
+    /**
+     * convert str from String to ImageData(Uint8ClampedArray)
+     * @param {string} str
+     *
+     * @return {Uint8ClampedArray}
+     */
+    convertToImageData (text) {
+      const padding = [[0, 0, 255], [0, 255], [255]]
+      let code, // 当前字节
+          counter = 0, // 计数器，用于记录数组长度,
+          buffer = [], // 临时容器
+          i = -1 // 循环指示器
+
+      while((code = text.charCodeAt(++i))) {
+        counter++
+        if (counter % 4 === 0) {
+          buffer.push(255)
+          counter++
+        }
+        buffer.push(code)
+      }
+
+      if (buffer.length % 4) {
+        buffer = buffer.concat(padding[buffer.length % 4 - 1])
+      }
+      return buffer
+      // console.log(buffer)
+    }
+
+    encode (str) {
+      let text = this[encodeUTF8](str),
+          canvas = this.canvas,
+          imagedata,
+          ctx
+
+      imagedata = this.convertToImageData(text)
+
+      ctx = this.createContainer(imagedata)
+
+      if (typeof ImageData === undefined) {
+        let _imagedata
+        _imagedata = ctx.createImageData(canvas.width, canvas.height)
+        imagedata.forEach( (d, i) => _imagedata.data[i] = d)
+        ctx.putImageData(_imagedata, 0, 0)
+      } else {
+        ctx.putImageData(
+          new ImageData(Uint8ClampedArray.from(imagedata), canvas.width, canvas.height), 0, 0
+        )
+      }
+
+      return canvas.toDataURL(`image/${this.config.img}`)
+    }
+
+    decode (url) {
+      let img = document.createElement('img')
+
+      img.crossOrigin = "anonymous"
+      img.src = url
+
+      return new Promise ((resolve, reject) => {
+	img.onload = () => {
+	  let canvas = document.createElement('canvas')
+	  canvas.width = img.width
+	  canvas.height = img.height
+
+	  let ctx = canvas.getContext("2d")
+	  ctx.drawImage(img, 0, 0)
+	  let imgData = ctx.getImageData(0, 0, canvas.width, canvas.height)
+
+	  let decodeArr = []
+	  for (let i = 0, l = imgData.data.length; i < l; i++) {
+	    if (i % 4 == 3) continue
+	    if (!imgData.data[i]) break
+	    decodeArr.push(String.fromCharCode(imgData.data[i]))
+	  }
+	  resolve(decodeURIComponent(decodeArr.join('')))
 	}
+      })
+    }
+  }
 
-	[encodeUTF8] (str) {
-		return str
-			.replace(/[\u0080-\u07ff]/g, (s) => {
-				let _s = s.charCodeAt(0)
-				return String.fromCharCode(0xc0 | _s >> 6, 0x80 | _s & 0x3f)
-			})
-			.replace(/[\u0800-\uffff]/g, (s) => {
-				let _s = s.charCodeAt(0)
-				return String.fromCharCode(0xe0 | _s >> 12, 0x80 | _s >> 6 & 0x3f, 0x80 | _s & 0x3f)
-			})
-	}
+  if (typeof module === 'object' && typeof module.exports === 'object') {
+    // CommonJS
+    module.exports = exports = Sphinx
 
-	encode (str) {
-		str += '      '
-		let text = this[encodeUTF8](str)
-		let pixelNum = Math.ceil((text.length) / 3) // One pixel could store 3 bytes by its RGB
-		let canvas = document.createElement('canvas')
-	  canvas.width = canvas.height = Math.ceil(Math.sqrt(pixelNum))
+  } else if (typeof define === 'function' && define.amd) {
+    // AMD support
+    define(() => Sphinx)
 
-	  let ctx = canvas.getContext('2d'),
-	  		imgData = ctx.createImageData(canvas.width, canvas.height)
-
-	  for(let i = 0, j = 0, l = imgData.data.length; i < l; i++){
-      if (i % 4 == 3) {
-        imgData.data[i] = 255
-        continue
-      }  
-      let code = text.charCodeAt(j++)
-      if (isNaN(code)) break
-      imgData.data[i] = code
-	  } 
-
-	  ctx.putImageData(imgData, 0, 0)
-	  return canvas.toDataURL(`image/${this.config.img}`)
-	}
-
-	decode (url) {
-		let img = document.createElement('img')
-		
-		img.crossOrigin = "anonymous"
-		img.src = url
-
-		return new Promise ((resolve, reject) => {
-			img.onload = () => {
-				let canvas = document.createElement('canvas')
-				canvas.width = img.width
-	      canvas.height = img.height
-
-	      let ctx = canvas.getContext("2d")
-	      ctx.drawImage(img, 0, 0)
-	      let imgData = ctx.getImageData(0, 0, canvas.width, canvas.height)
-
-	      let decodeArr = []
-	      for (let i = 0, l = imgData.data.length; i < l; i++) {  
-	        if (i % 4 == 3) continue
-	        if (!imgData.data[i]) break
-	        decodeArr.push(String.fromCharCode(imgData.data[i]))
-	      }
-	      resolve(decodeURIComponent(decodeArr.join('')))
-			}
-		})
-	}
-}
-
-if (typeof module === 'object' && typeof module.exports === 'object') {
-  // CommonJS
-  module.exports = exports = Sphinx
-
-} else if (typeof define === 'function' && define.amd) {
-  // AMD support
-  define(() => Sphinx)
-
-} else if (typeof window === 'object') {
-  // Normal way
-  window.Sphinx = Sphinx
-}
+  } else if (typeof window === 'object') {
+    // Normal way
+    window.Sphinx = Sphinx
+  }
 
 })()

--- a/test/sphinx.test.html
+++ b/test/sphinx.test.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Sphinx</title>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="description" content="sphinx">
+    <meta name="keywords" content="sphinx">
+    <link rel="stylesheet" href="https://code.jquery.com/qunit/qunit-2.1.1.css">
+  </head>
+  <body>
+
+    <div id="qunit"></div>
+    <div id="qunit-fixture"></div>
+
+    <script src="https://code.jquery.com/qunit/qunit-2.1.1.js"></script>
+    <script src="../src/sphinx.js"></script>
+    <script src="./test.js"></script>
+  </body>
+</html>

--- a/test/test.js
+++ b/test/test.js
@@ -1,0 +1,17 @@
+(function (window) {
+  "use strict"
+
+  QUnit.test("test encode & decode", function ( assert ) {
+    const sphinx = new Sphinx
+    const data = '我爱这个世界ABC123˙©ƒ'
+    const result = sphinx.encode(data)
+    const done = assert.async()
+
+    sphinx.decode(result).then( (text) => {
+      assert.equal(sphinx.decodeUTF8(text), data, 'encode-string is equal to decode-string')
+      done()
+    });
+
+  })
+
+})(window)

--- a/test/test.js
+++ b/test/test.js
@@ -4,11 +4,12 @@
   QUnit.test("test encode & decode", function ( assert ) {
     const sphinx = new Sphinx
     const data = '我爱这个世界ABC123˙©ƒ'
-    const result = sphinx.encode(data)
     const done = assert.async()
 
-    sphinx.decode(result).then( (text) => {
-      assert.equal(sphinx.decodeUTF8(text), data, 'encode-string is equal to decode-string')
+    sphinx.decode(
+      sphinx.encode(data)
+    ).then( (text) => {
+      assert.equal(text, data, 'encode-string is equal to decode-string')
       done()
     });
 


### PR DESCRIPTION
主要完成3个工作：
1. 使用 JS “自带的函数”进行 utf8 的编解码，代码更少。并使其支持对中文的处理。
2. 重写部分函数，使其更加有 JS 的风格（个人认为:smile:）
3. 增加测试用例，保证核心功能正常。